### PR TITLE
Add explicit permissions to workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ and automatically exempt bots.
      pull_request_target:
        types: [opened, closed, synchronize]
 
+   permissions:
+     actions: write
+     contents: write
+     pull-requests: write
+     statuses: write
+
    jobs:
      cla:
        runs-on: ubuntu-latest


### PR DESCRIPTION
I've noticed that the CLA workflow failed to write to the correct branch despite the repo being set up according to instruction (failing logs [here](https://github.com/cowprotocol/snapshot-settings/actions/runs/6802542630/job/18495854385)).

I believe the reason is missing permissions to write to the repo. In fact, I solved it by changing the following setting in the repo:
Actions → General → Workflow permissions: Read and write permission

I believe it used to be like that by default. However, it makes sense to not allow it by default, and I believe that with the changes in this PR there should be no need to do that. I copied the needed permissions from [here](https://github.com/contributor-assistant/github-action/tree/a895a435fcce79ecf28fbce61a4ef0f0dabc9853#1-add-the-following-workflow-file-to-your-repository-in-this-pathgithubworkflowsclayml).

### Test plan

See that these changes make CI work in [this PR](https://github.com/cowprotocol/snapshot-settings/pull/3).