### PR TITLE
Add workaround for failed action

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,19 @@ and automatically exempt bots.
    git push -u origin cla-signatures
    ```
 3. Profit $$$
+
+## Troubleshoot
+
+###  Error: Could not retrieve repository contents: Not Found. Status: 404
+
+If this happened on a repository with no contributors, you can try to create an
+empty contributor file for the action to populate. 
+
+```sh
+git checkout cla-signatures
+mkdir -p signatures/version1/
+echo $'{\n  "signedContributors": []\n}' > signatures/version1/cla.json
+```
+
+Then commit and push. [This](https://github.com/cowprotocol/flash-loan-wrapper-solver/pull/1)
+is an example PR where this workaround helped.


### PR DESCRIPTION
I've had an issue with this action [failing](https://github.com/cowprotocol/flash-loan-wrapper-solver/actions/runs/13071434597/job/36473778174) with the following error:

```
Run contributor-assistant/github-action@v2.2.1
CLA Assistant GitHub Action bot has started the process
Error: Could not retrieve repository contents: Not Found. Status: 404
Error: Cannot read properties of undefined (reading 'data')
```

This is a workaround to make the CI action work as expected.
The CLA action failed in [this PR](https://github.com/cowprotocol/flash-loan-wrapper-solver/pull/1).

This helpful workaround was suggested in https://github.com/contributor-assistant/github-action/issues/155#issuecomment-2190310649.

I didn't add it to the standard instructions because I'm not sure it's always necessary. I suspect the issue might be caused because the PR was created when the repo was private and making it public still left it in a stuck state.